### PR TITLE
hbase version updated

### DIFF
--- a/ansible/roles/hbase/vars/main.yml
+++ b/ansible/roles/hbase/vars/main.yml
@@ -1,8 +1,8 @@
 ---
-hbase_release: hbase-0.98.8
+hbase_release: hbase-0.98.9
 hbase_archive: '{{ hbase_release }}-hadoop{{ hadoop_major_version }}-bin.tar.gz'
 hbase_hadoop1_sha256: 'f99ae326b44d05d0cbcaccab0ac12cafbfcbc6140e023cda1d6b9fbc4e13d385'
-hbase_hadoop2_sha256: '665f55eca3ca54b3abcbe8d6fe3b918d64e387ec5f5c61ab79506cc42f567d5b'
+hbase_hadoop2_sha256: 'bd8eebba16bf05b2e4ce5caca1a48a4609d4e18756396ffac50dfd79badebbb4'
 hbase_home_dir: '/home/vagrant/{{ hbase_release }}-hadoop{{ hadoop_major_version }}'
 hbase_data_dir: /data/hbase
 zookeeper_data_dir: /data/zk


### PR DESCRIPTION
HBase version was updated, because the version 0.98.8 is not exists on the server anymore, and vagrant up will fail.